### PR TITLE
Correct a typo in generic-principles

### DIFF
--- a/stage1/tasks/clean-code/guidelines/generic-principles.md
+++ b/stage1/tasks/clean-code/guidelines/generic-principles.md
@@ -178,7 +178,6 @@ if (weekDay === 'Sunday' || weekDay === 'Saturday' ) {
 const today = new Date();
 const weekday = today.getDay();
 
-// non DRY code
 if (weekDay === 'Sunday' || weekDay === 'Saturday' ) {
     logDayPlan(today, 'sleep, eat, rest');
 } else {


### PR DESCRIPTION
Мне кажется строка ``` //non DRY code ```, та что выделена красным прямоугольником, - это опечатка. Я ее убрал.
![image](https://user-images.githubusercontent.com/60056105/112258527-9d343600-8ca1-11eb-805b-ad5f3ab004e0.png)

